### PR TITLE
Fix: sometimes transition animation does not work

### DIFF
--- a/src/AnimatedNumberItem.tsx
+++ b/src/AnimatedNumberItem.tsx
@@ -15,6 +15,7 @@ const AnimatedNumberItem: React.FC<AnimatedNumberItemProps> = ({
   order = "asc",
 }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [transformStyle, setTransformStyle] = useState<CSSProperties>({});
 
   const numberWrapperRef = useRef<HTMLDivElement>(null);
 
@@ -25,9 +26,11 @@ const AnimatedNumberItem: React.FC<AnimatedNumberItemProps> = ({
   useEffect(() => {
     const $numberWrapper = numberWrapperRef.current;
     if ($numberWrapper) {
-      $numberWrapper.style.transform = `translateY(${
-        size * (order === "desc" ? 9 - currentIndex : currentIndex) * -1
-      }px)`;
+      requestAnimationFrame(() => {
+          setTransformStyle({
+              transform: `translateY(${size * (order === "desc" ? 9 - currentIndex : currentIndex) * -1}px)`
+          });
+      });
     }
   }, [currentIndex, size, order]);
 
@@ -36,7 +39,7 @@ const AnimatedNumberItem: React.FC<AnimatedNumberItemProps> = ({
       <div
         ref={numberWrapperRef}
         className="AnimatedNumberItem__wrapper"
-        style={{ transitionDuration: `${duration}ms` }}
+        style={{ transitionDuration: `${duration}ms`, ...transformStyle }}
       >
         {Array.from({ length: 10 }).map((_, number) => (
           <div


### PR DESCRIPTION
## Problems

I wrote the code that the component area is unmounted when it is off the screen and mounted when the scroll is back in place.
However, the status of CSS animation using transition-duration and transform was immediately shown on the screen after it had already been terminated.


**Example**

https://github.com/eunvanz/react-awesome-animated-number/assets/59174247/965779d1-9a3b-4d33-a4ea-9120304c304a



[1. link with problem](https://codesandbox.io/s/angry-jennings-dinhqf?file=/src/App.tsx)
[2. link with solved code](https://codesandbox.io/s/serene-wright-jxj947?file=/src/App.tsx)